### PR TITLE
Support test suites that use gevent.

### DIFF
--- a/pytest_annotate/plugin.py
+++ b/pytest_annotate/plugin.py
@@ -15,8 +15,8 @@ class PyAnnotatePlugin(object):
     def pytest_collection_finish(self, session):
         """Handle the pytest collection finish hook: configure pyannotate.
 
-        Explicitly delay importing `collect_types` all tests have been collected.  This gives
-        gevent a chance to monkey patch the world before importing pyannotate.
+        Explicitly delay importing `collect_types` until all tests have been collected. This
+        gives gevent a chance to monkey patch the world before importing pyannotate.
         """
         from pyannotate_runtime import collect_types  # noqa
         self.collect_types = collect_types
@@ -24,18 +24,15 @@ class PyAnnotatePlugin(object):
 
     def pytest_unconfigure(self, config):
         """Unconfigure the pytest plugin. Happens when pytest is about to exit."""
-        if self.collect_types:
-            self.collect_types.dump_stats(self.output_file)
+        self.collect_types.dump_stats(self.output_file)
 
     def pytest_runtest_call(self):
         """Handle the pytest hook event that a test is about to be run: start type collection."""
-        if self.collect_types:
-            self.collect_types.resume()
+        self.collect_types.resume()
 
     def pytest_runtest_teardown(self):
         """Handle the pytest test end hook event: stop type collection."""
-        if self.collect_types:
-            self.collect_types.pause()
+        self.collect_types.pause()
 
 
 def pytest_addoption(parser):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 package_name = 'pytest-annotate'
-version = '1.0.1'
+version = '1.0.2'
 
 setup(
     name=package_name,


### PR DESCRIPTION
Currently pytest_annotate will hang indefinetly if the code under test
has been monkey patched with gevent.  To support this, we delay importing
pyannotate until after tests have been collected, which will import anything
that was going to monkey patch the world.