### PR TITLE
Allow pytest v4 and v5 as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyannotate>=1.0.0,<2.0.0',
-        'pytest>=3.2.0,<4.0.0'
+        'pytest>=3.2.0,<6.0.0'
     ],
     entry_points={
         'pytest11': [


### PR DESCRIPTION
Fixes https://github.com/kensho-technologies/pytest-annotate/issues/6

I noticed (anecdotally) that pytest-annotate works wonders also using pytest 5.1